### PR TITLE
Expose the simulation as a live webapp (closes #19)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,6 +18,6 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
 # [Optional] Uncomment this section to install additional vcpkg ports.
 # RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
 
-# [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# needed to build the webapp target, which serves the simulation over HTTP
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends pkg-config libulfius-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [8080],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "gcc -v",

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 mb_app
+mb_webapp
 tests
 log.mbapp.txt
 log.microbiome.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 WORKDIR /microbiome
 
 # add build tools
-RUN apt-get update && apt-get install -y make g++
+RUN apt-get update && apt-get install -y make g++ pkg-config libulfius-dev
 
 # add source code
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 MAIN_FILE = src/mbapp.cpp
 TESTS_FILE = src/tests.cpp
+WEBAPP_FILE = src/webapp.cpp
 PROJECT_FILES = src/microorganism.cpp src/microbiome.cpp src/appConfig.cpp src/simulation.cpp src/result.cpp src/logger.cpp src/microorganismFactory.cpp src/biomatter.cpp
+WEB_FILES = src/webServer.cpp
 ENVLIBCPP_FILES = env-lib-cpp/src/entity.cpp env-lib-cpp/src/environment.cpp env-lib-cpp/src/grid.cpp env-lib-cpp/src/location.cpp
 
 WARNING_FLAGS = -pedantic -Wall
+ULFIUS_FLAGS = $(shell pkg-config --cflags --libs libulfius jansson)
 
-all: mbapp tests
+all: mbapp tests webapp
 
 mbapp: src/mbapp.cpp
 	g++ $(WARNING_FLAGS) $(MAIN_FILE) $(PROJECT_FILES) $(ENVLIBCPP_FILES)  -o mb_app
 
 tests: src/tests.cpp
-	g++ $(WARNING_FLAGS) $(PROJECT_FILES) $(ENVLIBCPP_FILES) $(TESTS_FILE) -o tests
+	g++ $(WARNING_FLAGS) -pthread $(PROJECT_FILES) $(WEB_FILES) $(ENVLIBCPP_FILES) $(TESTS_FILE) $(ULFIUS_FLAGS) -o tests
+
+webapp: src/webapp.cpp
+	g++ $(WARNING_FLAGS) -pthread $(PROJECT_FILES) $(WEB_FILES) $(ENVLIBCPP_FILES) $(WEBAPP_FILE) $(ULFIUS_FLAGS) -o mb_webapp

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ Ticks elapsed: 16 of 120
 7. Open a terminal in VSCode.
 8. Run the `./cr.sh` script or build the project with `make` and run it with `./mb_app`.
 
+### How to view the simulation live in a browser
+The `webapp` target builds a small [Ulfius](https://github.com/babelouest/ulfius)-based web server (`mb_webapp`) that runs the simulation continuously and serves a live view of it.
+
+With Docker Compose:
+1. Run `docker-compose up --build microbiome-webapp`
+2. Open http://localhost:8080 in a browser
+
+Building locally (in addition to `make g++`, this needs `libulfius-dev` and `pkg-config`, e.g. `apt-get install pkg-config libulfius-dev` on Debian/Ubuntu):
+1. Run `make webapp`
+2. Run `./mb_webapp` (set `MICROBIOME_WEB_PORT` to use a port other than the default 8080)
+3. Open http://localhost:8080 in a browser
+
+The page polls `GET /api/state` a few times a second for the current grid, microorganisms, and biomatter as JSON, and once the population goes extinct the server starts a new generation automatically.
+
 ## Notable Classes
 
 ### Microbiome
@@ -63,6 +77,9 @@ The Microorganism class represents a single microbe. It is an extension of the E
 
 ### Biomatter
 The Biomatter class represents decomposing biomass left behind when a microorganism dies. It is an extension of the Entity class provided by env-lib-cpp. Living microorganisms bias their movement toward it (chemotaxis) and can forage it for energy, modeling nutrient recycling instead of dead microorganisms simply vanishing from the energy budget.
+
+### WebServer
+The WebServer class (built on [Ulfius](https://github.com/babelouest/ulfius), see [#19](https://github.com/Preponderous-Software/microbiome/issues/19)) runs a Microbiome simulation continuously in the background and exposes its state over HTTP, so it can be viewed live at http://localhost:8080 instead of only in the console.
 
 ## Simulated Mechanics
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,10 @@ services:
       dockerfile: Dockerfile
     environment:
     - "TERM=xterm"
+  microbiome-webapp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ["./mb_webapp"]
+    ports:
+    - "8080:8080"

--- a/src/header/microbiome.h
+++ b/src/header/microbiome.h
@@ -25,6 +25,7 @@ class Microbiome : public Environment {
         void printConsoleRepresentation();
         void removeEntity(Entity& entity);
         std::vector<Microorganism*> getMicroorganisms();
+        std::vector<Biomatter*> getBiomatter();
         int getNumAliveMicroorganisms();
         int getNumDeadMicroorganisms();
         int getTotalEnergy();

--- a/src/header/webServer.h
+++ b/src/header/webServer.h
@@ -1,0 +1,44 @@
+#ifndef WebServer_h
+#define WebServer_h
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+
+#include "appConfig.h"
+#include "microbiome.h"
+
+struct _u_instance;
+struct _u_response;
+
+/**
+ * The WebServer class hosts a small REST API and web page (built on Ulfius)
+ * that expose the state of a continuously-running Microbiome simulation, so
+ * it can be viewed live in a browser instead of only in the console.
+ * @author Daniel McCoy Stephenson
+ */
+class WebServer {
+    public:
+        WebServer(AppConfig* config, int port);
+        ~WebServer();
+        void run();
+        void stop();
+        void writeStateResponse(_u_response* response);
+        void writeIndexResponse(_u_response* response);
+    private:
+        void runSimulationLoop();
+
+        AppConfig* config;
+        int port;
+        _u_instance* instance;
+        Microbiome* microbiome = nullptr;
+        std::mutex stateMutex;
+        std::atomic<bool> keepRunning{false};
+        std::thread simulationThread;
+
+        int tickIntervalMs = 200;
+        int generation = 0;
+        int tickCount = 0;
+};
+
+#endif

--- a/src/microbiome.cpp
+++ b/src/microbiome.cpp
@@ -258,6 +258,14 @@ std::vector<Microorganism*> Microbiome::getMicroorganisms() {
     return result;
 }
 
+std::vector<Biomatter*> Microbiome::getBiomatter() {
+    std::vector<Biomatter*> result;
+    for (std::unique_ptr<Biomatter>& b : biomatter) {
+        result.push_back(b.get());
+    }
+    return result;
+}
+
 int Microbiome::getNumAliveMicroorganisms() {
     int numAlive = 0;
     for (std::unique_ptr<Microorganism>& microorganism : microorganisms) {

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -2,10 +2,16 @@
 #include <Windows.h>
 #else
 #include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #endif
 
+#include <chrono>
+#include <cstring>
 #include <string>
 #include <iostream>
+#include <thread>
 #include <assert.h>
 
 #include "header/appConfig.h"
@@ -13,6 +19,7 @@
 #include "header/result.h"
 #include "header/microorganism.h"
 #include "header/microbiome.h"
+#include "header/webServer.h"
 
 void testTemplate() {
     std::cout << "Test - Template";
@@ -238,6 +245,66 @@ void testSimulationResults() {
     std::cout << " --- " << "Success" << std::endl;
 }
 
+// web server tests -------------------------------------------------------------
+std::string httpGetBody(int port, std::string path) {
+    for (int attempt = 0; attempt < 40; attempt++) {
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        struct sockaddr_in addr;
+        std::memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(port);
+        inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+        if (connect(sock, (struct sockaddr*) &addr, sizeof(addr)) == 0) {
+            std::string request = "GET " + path + " HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+            send(sock, request.c_str(), request.size(), 0);
+
+            std::string response;
+            char buffer[4096];
+            ssize_t bytesRead;
+            while ((bytesRead = recv(sock, buffer, sizeof(buffer), 0)) > 0) {
+                response.append(buffer, bytesRead);
+            }
+            close(sock);
+
+            size_t bodyStart = response.find("\r\n\r\n");
+            if (bodyStart == std::string::npos) {
+                return "";
+            }
+            return response.substr(bodyStart + 4);
+        }
+
+        // server may not have started listening yet
+        close(sock);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return "";
+}
+
+void testWebServerServesSimulationState() {
+    std::cout << "Test - Web Server Serves Simulation State";
+
+    AppConfig config;
+    config.setEnvironmentSize(3);
+    config.setEntityFactor(1);
+    config.setSimulationOutputEnabled(false);
+
+    int port = 18123;
+    WebServer server(&config, port);
+    std::thread serverThread(&WebServer::run, &server);
+
+    std::string body = httpGetBody(port, "/api/state");
+
+    server.stop();
+    serverThread.join();
+
+    assert(!body.empty());
+    assert(body.find("\"gridSize\":3") != std::string::npos);
+    assert(body.find("\"microorganisms\"") != std::string::npos);
+    assert(body.find("\"biomatter\"") != std::string::npos);
+    std::cout << " --- " << "Success" << std::endl;
+}
+
 
 void seedRandomNumberGenerator() {
     srand (time (NULL));
@@ -267,5 +334,8 @@ int main() {
     // run simulation tests
     testRunningSimulation();
     testSimulationResults();
+
+    // run web server tests
+    testWebServerServesSimulationState();
     return 0;
 }

--- a/src/webServer.cpp
+++ b/src/webServer.cpp
@@ -1,0 +1,275 @@
+#include "header/webServer.h"
+
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+
+#include <jansson.h>
+extern "C" {
+#include <ulfius.h>
+}
+
+namespace {
+    const char* INDEX_HTML = R"HTML(<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Microbiome</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #0b1210;
+    --panel: #111a17;
+    --text: #d8e6df;
+    --muted: #7fa08f;
+    --grid: #1c2b26;
+    --alive: #4fd67a;
+    --subsisting: #4fa9d6;
+    --dying: #e05252;
+    --biomatter: #b58a4a;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f4f7f5;
+      --panel: #ffffff;
+      --text: #16231d;
+      --muted: #4c6157;
+      --grid: #e3ebe6;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem 1rem 3rem;
+  }
+  h1 { margin: 0; font-size: 1.25rem; font-weight: 600; }
+  .subtitle { margin: 0; color: var(--muted); font-size: 0.85rem; }
+  .stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    background: var(--panel);
+    border-radius: 0.75rem;
+    padding: 0.75rem 1.25rem;
+    font-size: 0.85rem;
+  }
+  .stats span strong { color: var(--text); }
+  .stats span { color: var(--muted); }
+  canvas {
+    background: var(--grid);
+    border-radius: 0.75rem;
+    max-width: 100%;
+    height: auto;
+  }
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .legend span { display: inline-flex; align-items: center; gap: 0.4rem; }
+  .dot { width: 0.6rem; height: 0.6rem; border-radius: 50%; display: inline-block; }
+</style>
+</head>
+<body>
+  <h1>Microbiome</h1>
+  <p class="subtitle">a virtual microbial community, viewed live</p>
+  <div class="stats" id="stats"></div>
+  <canvas id="grid" width="600" height="600"></canvas>
+  <div class="legend">
+    <span><i class="dot" style="background:var(--alive)"></i>alive</span>
+    <span><i class="dot" style="background:var(--subsisting)"></i>foraging</span>
+    <span><i class="dot" style="background:var(--dying)"></i>low energy</span>
+    <span><i class="dot" style="background:var(--biomatter)"></i>biomatter</span>
+  </div>
+
+<script>
+  const canvas = document.getElementById("grid");
+  const ctx = canvas.getContext("2d");
+  const statsEl = document.getElementById("stats");
+  const style = getComputedStyle(document.documentElement);
+
+  function color(name) {
+    return style.getPropertyValue(name).trim();
+  }
+
+  function render(state) {
+    const cell = canvas.width / state.gridSize;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    for (const b of state.biomatter) {
+      ctx.fillStyle = color("--biomatter");
+      const size = cell * 0.35;
+      ctx.fillRect(b.x * cell + (cell - size) / 2, b.y * cell + (cell - size) / 2, size, size);
+    }
+
+    for (const m of state.microorganisms) {
+      let fill = color("--alive");
+      if (m.energy < 10) {
+        fill = color("--dying");
+      } else if (m.timesEaten > 0) {
+        fill = color("--subsisting");
+      }
+      ctx.fillStyle = fill;
+      ctx.beginPath();
+      ctx.arc(m.x * cell + cell / 2, m.y * cell + cell / 2, cell * 0.3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    statsEl.innerHTML = `
+      <span>generation <strong>${state.generation}</strong></span>
+      <span>tick <strong>${state.tick}</strong></span>
+      <span>alive <strong>${state.aliveCount}</strong></span>
+      <span>total deaths <strong>${state.deadCount}</strong></span>
+      <span>total energy <strong>${state.totalEnergy}</strong></span>
+    `;
+  }
+
+  async function poll() {
+    try {
+      const response = await fetch("/api/state");
+      const state = await response.json();
+      render(state);
+    } catch (err) {
+      // server may be between ticks or restarting a generation; try again shortly
+    } finally {
+      setTimeout(poll, 300);
+    }
+  }
+
+  poll();
+</script>
+</body>
+</html>
+)HTML";
+
+    int handleIndexRequest(const struct _u_request*, struct _u_response* response, void* userData) {
+        static_cast<WebServer*>(userData)->writeIndexResponse(response);
+        return U_CALLBACK_CONTINUE;
+    }
+
+    int handleStateRequest(const struct _u_request*, struct _u_response* response, void* userData) {
+        static_cast<WebServer*>(userData)->writeStateResponse(response);
+        return U_CALLBACK_CONTINUE;
+    }
+}
+
+WebServer::WebServer(AppConfig* appConfig, int listenPort) {
+    config = appConfig;
+    port = listenPort;
+    instance = new _u_instance();
+
+    std::lock_guard<std::mutex> lock(stateMutex);
+    microbiome = new Microbiome(generation++, "Web Simulation", config->getEnvironmentSize(), config->getEntityFactor());
+}
+
+WebServer::~WebServer() {
+    stop();
+    if (simulationThread.joinable()) {
+        simulationThread.join();
+    }
+    delete instance;
+    delete microbiome;
+}
+
+void WebServer::run() {
+    if (ulfius_init_instance(instance, port, NULL, NULL) != U_OK) {
+        throw std::runtime_error("Failed to initialize web server instance on port " + std::to_string(port));
+    }
+
+    ulfius_add_endpoint_by_val(instance, "GET", "/", NULL, 0, &handleIndexRequest, this);
+    ulfius_add_endpoint_by_val(instance, "GET", "/api/state", NULL, 0, &handleStateRequest, this);
+
+    keepRunning = true;
+    simulationThread = std::thread(&WebServer::runSimulationLoop, this);
+
+    if (ulfius_start_framework(instance) != U_OK) {
+        keepRunning = false;
+        simulationThread.join();
+        throw std::runtime_error("Failed to start web server on port " + std::to_string(port));
+    }
+
+    std::cout << "Serving microbiome simulation on http://localhost:" << port << std::endl;
+
+    while (keepRunning) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    ulfius_stop_framework(instance);
+    ulfius_clean_instance(instance);
+}
+
+void WebServer::stop() {
+    keepRunning = false;
+}
+
+void WebServer::runSimulationLoop() {
+    while (keepRunning) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(tickIntervalMs));
+
+        std::lock_guard<std::mutex> lock(stateMutex);
+        if (microbiome->getNumAliveMicroorganisms() == 0) {
+            delete microbiome;
+            tickCount = 0;
+            microbiome = new Microbiome(generation++, "Web Simulation", config->getEnvironmentSize(), config->getEntityFactor());
+            continue;
+        }
+
+        microbiome->initiateMicroorganismMovement();
+        tickCount++;
+    }
+}
+
+void WebServer::writeStateResponse(_u_response* response) {
+    std::lock_guard<std::mutex> lock(stateMutex);
+
+    json_t* root = json_object();
+    json_object_set_new(root, "generation", json_integer(generation));
+    json_object_set_new(root, "tick", json_integer(tickCount));
+    json_object_set_new(root, "gridSize", json_integer(microbiome->getGrid()->getSize()));
+    json_object_set_new(root, "aliveCount", json_integer(microbiome->getNumAliveMicroorganisms()));
+    json_object_set_new(root, "deadCount", json_integer(microbiome->getNumDeadMicroorganisms()));
+    json_object_set_new(root, "totalEnergy", json_integer(microbiome->getTotalEnergy()));
+
+    json_t* organisms = json_array();
+    for (Microorganism* organism : microbiome->getMicroorganisms()) {
+        Location& location = microbiome->getGrid()->getLocation(organism->getLocationId());
+        json_t* entry = json_object();
+        json_object_set_new(entry, "id", json_integer(organism->getId()));
+        json_object_set_new(entry, "x", json_integer(location.getX()));
+        json_object_set_new(entry, "y", json_integer(location.getY()));
+        json_object_set_new(entry, "energy", json_integer(organism->getEnergy()));
+        json_object_set_new(entry, "timesEaten", json_integer(organism->getTimesEaten()));
+        json_array_append_new(organisms, entry);
+    }
+    json_object_set_new(root, "microorganisms", organisms);
+
+    json_t* biomatterEntries = json_array();
+    for (Biomatter* b : microbiome->getBiomatter()) {
+        Location& location = microbiome->getGrid()->getLocation(b->getLocationId());
+        json_t* entry = json_object();
+        json_object_set_new(entry, "id", json_integer(b->getId()));
+        json_object_set_new(entry, "x", json_integer(location.getX()));
+        json_object_set_new(entry, "y", json_integer(location.getY()));
+        json_object_set_new(entry, "energy", json_integer(b->getEnergy()));
+        json_array_append_new(biomatterEntries, entry);
+    }
+    json_object_set_new(root, "biomatter", biomatterEntries);
+
+    ulfius_set_json_body_response(response, 200, root);
+    json_decref(root);
+}
+
+void WebServer::writeIndexResponse(_u_response* response) {
+    u_map_put(response->map_header, "Content-Type", "text/html; charset=utf-8");
+    ulfius_set_string_body_response(response, 200, INDEX_HTML);
+}

--- a/src/webServer.cpp
+++ b/src/webServer.cpp
@@ -17,7 +17,7 @@ namespace {
 <title>Microbiome</title>
 <style>
   :root {
-    color-scheme: light dark;
+    color-scheme: dark;
     --bg: #0b1210;
     --panel: #111a17;
     --text: #d8e6df;
@@ -27,15 +27,6 @@ namespace {
     --subsisting: #4fa9d6;
     --dying: #e05252;
     --biomatter: #b58a4a;
-  }
-  @media (prefers-color-scheme: light) {
-    :root {
-      --bg: #f4f7f5;
-      --panel: #ffffff;
-      --text: #16231d;
-      --muted: #4c6157;
-      --grid: #e3ebe6;
-    }
   }
   * { box-sizing: border-box; }
   body {

--- a/src/webapp.cpp
+++ b/src/webapp.cpp
@@ -1,0 +1,20 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "header/appConfig.h"
+#include "header/webServer.h"
+
+int main() {
+    AppConfig config;
+    config.setSimulationOutputEnabled(false);
+
+    int port = 8080;
+    const char* portFromEnv = std::getenv("MICROBIOME_WEB_PORT");
+    if (portFromEnv != nullptr) {
+        port = std::atoi(portFromEnv);
+    }
+
+    WebServer server(&config, port);
+    server.run();
+    return 0;
+}


### PR DESCRIPTION
## Summary
Stacked on #24 (which is stacked on #23). Implements [#19](https://github.com/Preponderous-Software/microbiome/issues/19) ("Use Ulfius library to implement a simple REST service") as a live web view of the simulation, since that's what makes RESEARCH.md's mechanics actually watchable outside the console.

- A new `WebServer` class (`src/webServer.cpp` / `src/header/webServer.h`), built on [Ulfius](https://github.com/babelouest/ulfius) per the issue, runs a `Microbiome` continuously in a background thread and serves:
  - `GET /` — a small self-contained HTML/canvas page (no external assets/CDN) that polls the state endpoint a few times a second and renders alive/foraging/dying microorganisms and biomatter on a canvas, plus generation/tick/alive/cumulative-death/total-energy stats.
  - `GET /api/state` — the same state as JSON.
- Once a generation's population goes extinct, the server starts a fresh `Microbiome` automatically so the page keeps updating indefinitely rather than the process just exiting.
- A mutex guards the `Microbiome` pointer between the simulation-tick thread and the HTTP handler thread.
- New `mb_webapp` binary (`make webapp`), a `microbiome-webapp` docker-compose service on port 8080, and `libulfius-dev`/`pkg-config` added to the Dockerfile and devcontainer. `mbapp`/`tests` still build without any new runtime dependency for the console app itself — `tests` now also links Ulfius/Jansson, but only because it covers the new web server integration test below.
- Added `Microbiome::getBiomatter()` (mirroring the existing `getMicroorganisms()`) since the web layer needs to render biomatter too.

### A build gotcha worth flagging
`/usr/include/ulfius.h` isn't wrapped in `extern "C"`, so `ulfius_*` calls compiled as C++ get C++ name-mangled and fail to link against the C-compiled `libulfius.so` unless the include itself is wrapped in `extern "C" { ... }` (done in `webServer.cpp`).

## Test plan
- `make tests && ./tests` — all existing tests pass, plus a new `testWebServerServesSimulationState`, which starts a `WebServer` on a background thread, hits `/api/state` with a small dependency-free raw-socket HTTP client (no new library needed just for the test), and asserts the JSON shape. Ran 5x locally with no flakiness.
- `make webapp && MICROBIOME_WEB_PORT=<port> ./mb_webapp` — ran it locally and hit it with `curl`: confirmed `GET /` returns the HTML page with `Content-Type: text/html`, and `GET /api/state` returns valid JSON whose `aliveCount`/`deadCount`/`totalEnergy` moved sensibly over ~150 ticks (76 alive, 38 cumulative deaths, 3 biomatter patches on the grid at that point).
- `make mbapp` — unaffected, builds and runs exactly as before with no new dependency.
- Verified locally on Ubuntu 20.04 with `libulfius-dev` 2.5.2 from the `focal/universe` apt repo. The project's `Dockerfile` targets `ubuntu:18.04`, which packages an older `libulfius-dev` 2.2.4 from `bionic/universe` (confirmed present in the archive) — I could not verify that exact image build since there's no Docker daemon available in this environment, but the APIs used here (`ulfius_init_instance`, `ulfius_add_endpoint_by_val`, `ulfius_start/stop_framework`, `ulfius_set_json_body_response`, `ulfius_set_string_body_response`) are long-stable Ulfius 2.x entry points.

Drafted by Claude on behalf of Daniel Stephenson.