### PR TITLE
Align mechanics with RESEARCH.md: reproduction, biomatter, chemotaxis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAIN_FILE = src/mbapp.cpp
 TESTS_FILE = src/tests.cpp
-PROJECT_FILES = src/microorganism.cpp src/microbiome.cpp src/appConfig.cpp src/simulation.cpp src/result.cpp src/logger.cpp src/microorganismFactory.cpp
+PROJECT_FILES = src/microorganism.cpp src/microbiome.cpp src/appConfig.cpp src/simulation.cpp src/result.cpp src/logger.cpp src/microorganismFactory.cpp src/biomatter.cpp
 ENVLIBCPP_FILES = env-lib-cpp/src/entity.cpp env-lib-cpp/src/environment.cpp env-lib-cpp/src/grid.cpp env-lib-cpp/src/location.cpp
 
 WARNING_FLAGS = -pedantic -Wall

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ The Microbiome class represents a virtual microbial community. It is an extensio
 ### Microorganism
 The Microorganism class represents a single microbe. It is an extension of the Entity class provided by env-lib-cpp. The Microorganism class is responsible for managing the microbe's energy and metabolism.
 
+### Biomatter
+The Biomatter class represents decomposing biomass left behind when a microorganism dies. It is an extension of the Entity class provided by env-lib-cpp. Living microorganisms bias their movement toward it (chemotaxis) and can forage it for energy, modeling nutrient recycling instead of dead microorganisms simply vanishing from the energy budget.
+
+## Simulated Mechanics
+
+See [RESEARCH.md](RESEARCH.md) for the microbiology background behind these mechanics and what's still missing.
+
+- **Metabolism** - every microorganism loses energy each tick and dies once its energy reaches zero.
+- **Decomposition** - a dead microorganism's biomass becomes Biomatter in the environment rather than an inert corpse.
+- **Chemotaxis** - microorganisms bias their movement toward neighboring locations that have Biomatter, rather than moving with pure uniform randomness.
+- **Foraging** - a microorganism sharing a location with Biomatter can consume it for energy, depleting it over time.
+- **Reproduction** - a microorganism that accumulates enough energy divides via binary fission into two daughter cells, each inheriting half its remaining energy (minus the energetic cost of dividing) and its metabolic rate.
+
 ## 📄 License
 
 This project is licensed under the **Preponderous Non-Commercial License (Preponderous-NC)**.  

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -188,11 +188,16 @@ Not a commitment, but a sensible dependency order given the above — several
 later items are much more interesting once the earlier ones exist:
 
 1. **Reproduction** (#13) — nothing else about population/evolutionary
-   dynamics is meaningful without it.
+   dynamics is meaningful without it. **Implemented**: binary fission once
+   energy crosses a threshold, minus a fission cost (see `Microbiome::initiateReproduction`).
 2. **Biomatter on death** (#14) — closes the energy budget and creates a real
    nutrient pool to build chemotaxis and cross-feeding on top of.
+   **Implemented**: dead organisms are replaced by a foragable `Biomatter`
+   entity instead of an inert corpse (see `Microbiome::processDeath`).
 3. **Chemotaxis toward nutrient/biomatter** — cheap, high visual/behavioral
    payoff once there's something in the environment worth moving toward.
+   **Implemented**: movement is probabilistically biased toward adjacent
+   cells containing biomatter (see `Microbiome::moveMicroorganism`).
 4. **Species differentiation** (trait profiles, then divergent metabolism) —
    turns "a microorganism" into "a microbiome."
 5. **Mutation on reproduction** — evolution falls out of 1 and 4 almost for

--- a/src/biomatter.cpp
+++ b/src/biomatter.cpp
@@ -1,0 +1,17 @@
+#include "header/biomatter.h"
+
+Biomatter::Biomatter(int id, std::string name, int startingEnergy) : Entity(id, name) {
+    energy = startingEnergy;
+}
+
+int Biomatter::getEnergy() {
+    return energy;
+}
+
+void Biomatter::setEnergy(int newEnergy) {
+    energy = newEnergy;
+}
+
+bool Biomatter::isDepleted() {
+    return energy <= 0;
+}

--- a/src/header/biomatter.h
+++ b/src/header/biomatter.h
@@ -1,0 +1,24 @@
+#ifndef Biomatter_h
+#define Biomatter_h
+
+#include "../../env-lib-cpp/src/header/entity.h"
+
+using namespace envlibcpp;
+
+/**
+ * The Biomatter class represents decomposing biomass left behind when a
+ * microorganism dies. Living microorganisms can forage it for energy,
+ * modeling nutrient recycling in a real microbial community.
+ * @author Daniel McCoy Stephenson
+ */
+class Biomatter : public Entity {
+    public:
+        Biomatter(int id, std::string name, int energy);
+        int getEnergy();
+        void setEnergy(int energy);
+        bool isDepleted();
+    private:
+        int energy;
+};
+
+#endif

--- a/src/header/microbiome.h
+++ b/src/header/microbiome.h
@@ -1,10 +1,14 @@
 #ifndef Microbiome_h
 #define Microbiome_h
 
+#include <memory>
+#include <vector>
+
 #include "../../env-lib-cpp/src/header/environment.h"
 
 #include "microorganism.h"
 #include "microorganismFactory.h"
+#include "biomatter.h"
 #include "logger.h"
 
 using namespace envlibcpp;
@@ -20,29 +24,48 @@ class Microbiome : public Environment {
         void initiateMicroorganismMovement();
         void printConsoleRepresentation();
         void removeEntity(Entity& entity);
-        std::vector<Microorganism> getMicroorganisms();
+        std::vector<Microorganism*> getMicroorganisms();
         int getNumAliveMicroorganisms();
         int getNumDeadMicroorganisms();
         int getTotalEnergy();
         void purgeMicroorganismsNotInEnvironment();
-        bool isMicroorganismPresent(int id); 
+        bool isMicroorganismPresent(int id);
         void addMicroorganism(Microorganism microorganism);
         void removeMicroorganism(int id);
     private:
         void generateMicroorganisms(int numMicroorganisms);
         void addMicroorganismsToEnvironment();
-        void initiateConsumptionOfDeadMicroorganisms(Microorganism& microorganism);
-        
-        std::vector<Microorganism> microorganisms;
+        void moveMicroorganism(Microorganism& microorganism);
+        void initiateForaging(Microorganism& microorganism);
+        void initiateReproduction(Microorganism& microorganism);
+        void processDeath(Microorganism& microorganism);
+        void purgeDepletedBiomatter();
+        std::vector<Location*> getAdjacentLocations(Location& location);
+        Microorganism* getMicroorganismAtLocation(Location& location);
+        Biomatter* getBiomatterAtLocation(Location& location);
+
+        std::vector<std::unique_ptr<Microorganism>> microorganisms;
+        std::vector<std::unique_ptr<Biomatter>> biomatter;
         MicroorganismFactory microorganismFactory;
         Logger* logger;
-        
+        int nextEntityId = 0;
+        size_t totalDeaths = 0;
+
         // microbiome config options
         std::string aliveMicroorganismRepresentation = "o";
         std::string subsistingMicroorganismRepresentation = "+";
         std::string dyingMicroorganismRepresentation = "!";
-        std::string deadMicroorganismRepresentation = ".";
-        bool deadMicroorganismConsumptionEnabled = true;
+        std::string biomatterRepresentation = ".";
+        bool foragingEnabled = true;
+        bool reproductionEnabled = true;
+        bool chemotaxisEnabled = true;
+
+        // biology tuning constants
+        int reproductionEnergyThreshold = 900;
+        int fissionCost = 100;
+        int biomatterYieldPerDeath = 60;
+        int biomatterForagingMultiplier = 1;
+        int chemotaxisBiasPercent = 80;
 };
 
 #endif

--- a/src/microbiome.cpp
+++ b/src/microbiome.cpp
@@ -1,10 +1,14 @@
+#include <algorithm>
+#include <memory>
 #include <vector>
+
 #include "header/microbiome.h"
 
 Microbiome::Microbiome(int id, std::string name, int size, int entityFactor) : Environment(id, name, size) {
     logger = new Logger("log.microbiome.txt");
     generateMicroorganisms(size * entityFactor);
     addMicroorganismsToEnvironment();
+    nextEntityId = size * entityFactor;
 }
 
 Microbiome::~Microbiome() {
@@ -14,71 +18,189 @@ Microbiome::~Microbiome() {
 void Microbiome::generateMicroorganisms(int numMicroorganisms) {
     logger->log("Generating " + std::to_string(numMicroorganisms) + " microorganisms...");
     for (int i = 0; i < numMicroorganisms; i++) {
-        Microorganism microorganism = microorganismFactory.createMicroorganism();
-        microorganisms.push_back(microorganism);
+        microorganisms.push_back(std::make_unique<Microorganism>(microorganismFactory.createMicroorganism()));
     }
 }
 
 void Microbiome::addMicroorganismsToEnvironment() {
     logger->log("Adding microorganisms to environment...");
-    for (Microorganism& microorganism : microorganisms) {
-        addEntity(microorganism);
+    for (std::unique_ptr<Microorganism>& microorganism : microorganisms) {
+        addEntity(*microorganism);
     }
 }
 
 void Microbiome::initiateMicroorganismMovement() {
     logger->log("Initiating microorganism movement...");
     for (size_t i = 0; i < microorganisms.size(); i++) {
-        Microorganism& microorganism = microorganisms[i];
+        Microorganism& microorganism = *microorganisms[i];
         if (microorganism.isDead()) {
             continue;
         }
-        Microorganism& retrievedMicroorganism = (Microorganism&) getEntity(microorganism.getId());     
-        moveEntityToRandomAdjacentLocation(retrievedMicroorganism.getId());
-        retrievedMicroorganism.incrementTimesMoved();
-        retrievedMicroorganism.metabolize();
 
-        if (deadMicroorganismConsumptionEnabled) {
-            initiateConsumptionOfDeadMicroorganisms(retrievedMicroorganism);
+        moveMicroorganism(microorganism);
+        microorganism.incrementTimesMoved();
+        microorganism.metabolize();
+
+        if (microorganism.isDead()) {
+            processDeath(microorganism);
+            continue;
+        }
+
+        if (foragingEnabled) {
+            initiateForaging(microorganism);
+        }
+
+        if (reproductionEnabled) {
+            initiateReproduction(microorganism);
         }
     }
+
+    purgeMicroorganismsNotInEnvironment();
+    purgeDepletedBiomatter();
 }
 
-void Microbiome::initiateConsumptionOfDeadMicroorganisms(Microorganism& microorganism ) {
-    // get location of microorganism
-    Location& microorganismLocation = getGrid()->getLocation(microorganism.getLocationId());
+std::vector<Location*> Microbiome::getAdjacentLocations(Location& location) {
+    std::vector<Location*> adjacentLocations;
+    int x = location.getX();
+    int y = location.getY();
+    int offsets[4][2] = {{0, -1}, {1, 0}, {0, 1}, {-1, 0}};
+    for (auto& offset : offsets) {
+        try {
+            Location& adjacent = getGrid()->getLocationByCoordinates(x + offset[0], y + offset[1]);
+            adjacentLocations.push_back(&adjacent);
+        } catch (const std::runtime_error* e) {
+            // no location at these coordinates; edge of the grid
+        }
+    }
+    return adjacentLocations;
+}
 
-    // get entities at location
-    std::vector<Entity*> entities = microorganismLocation.getEntities();
+Microorganism* Microbiome::getMicroorganismAtLocation(Location& location) {
+    for (Entity* entity : location.getEntities()) {
+        for (std::unique_ptr<Microorganism>& microorganism : microorganisms) {
+            if (microorganism->getId() == entity->getId()) {
+                return microorganism.get();
+            }
+        }
+    }
+    return nullptr;
+}
 
-    if (entities.size() == 1) {
+Biomatter* Microbiome::getBiomatterAtLocation(Location& location) {
+    for (Entity* entity : location.getEntities()) {
+        for (std::unique_ptr<Biomatter>& b : biomatter) {
+            if (b->getId() == entity->getId()) {
+                return b.get();
+            }
+        }
+    }
+    return nullptr;
+}
+
+void Microbiome::moveMicroorganism(Microorganism& microorganism) {
+    Location& currentLocation = getGrid()->getLocation(microorganism.getLocationId());
+    std::vector<Location*> adjacentLocations = getAdjacentLocations(currentLocation);
+    if (adjacentLocations.empty()) {
         return;
     }
 
-    // iterate through entities to check for the presence of a dead microorganism
-    Entity* toRemove = nullptr;
-    for (size_t i = 0; i < entities.size(); i++) {
-        Entity* entity = entities[i];
-        if (entity->getId() == microorganism.getId()) {
-            continue;
-        }
-        Microorganism& retrievedMicroorganism = (Microorganism&) *entity;
-        if (retrievedMicroorganism.isDead()) {
-            microorganism.incrementTimesEaten();
-            toRemove = entity;
-
-            // increase energy
-            int energy = microorganism.getEnergy();
-            int metabolicRate = microorganism.getMetabolicRate();
-            microorganism.setEnergy(energy + metabolicRate * 2);
-            break;
+    // chemotaxis: bias movement toward nutrient-rich neighboring locations,
+    // similar to how real bacteria bias a run-and-tumble walk up a nutrient
+    // gradient, rather than moving with pure uniform randomness.
+    std::vector<Location*> nutrientRichLocations;
+    if (chemotaxisEnabled) {
+        for (Location* candidate : adjacentLocations) {
+            if (getBiomatterAtLocation(*candidate) != nullptr) {
+                nutrientRichLocations.push_back(candidate);
+            }
         }
     }
 
-    // remove dead microorganism
-    if (toRemove != nullptr) {
-        removeEntity(*toRemove);
+    Location* destination;
+    if (!nutrientRichLocations.empty() && (rand() % 100) < chemotaxisBiasPercent) {
+        destination = nutrientRichLocations[rand() % nutrientRichLocations.size()];
     }
+    else {
+        destination = adjacentLocations[rand() % adjacentLocations.size()];
+    }
+
+    moveEntityToNewLocation(microorganism.getId(), destination->getId());
+}
+
+void Microbiome::initiateForaging(Microorganism& microorganism) {
+    Location& location = getGrid()->getLocation(microorganism.getLocationId());
+    Biomatter* foundBiomatter = getBiomatterAtLocation(location);
+    if (foundBiomatter == nullptr) {
+        return;
+    }
+
+    int amountForaged = std::min(foundBiomatter->getEnergy(), microorganism.getMetabolicRate() * biomatterForagingMultiplier);
+    if (amountForaged <= 0) {
+        return;
+    }
+
+    foundBiomatter->setEnergy(foundBiomatter->getEnergy() - amountForaged);
+    microorganism.setEnergy(microorganism.getEnergy() + amountForaged);
+    microorganism.incrementTimesEaten();
+}
+
+void Microbiome::initiateReproduction(Microorganism& microorganism) {
+    // binary fission: once an organism has accumulated enough energy, it
+    // splits into two daughter cells that share the parent's remaining
+    // energy (minus the energetic cost of dividing).
+    if (microorganism.getEnergy() < reproductionEnergyThreshold) {
+        return;
+    }
+
+    Location& currentLocation = getGrid()->getLocation(microorganism.getLocationId());
+    std::vector<Location*> adjacentLocations = getAdjacentLocations(currentLocation);
+    if (adjacentLocations.empty()) {
+        return;
+    }
+
+    int energyPerDaughter = (microorganism.getEnergy() - fissionCost) / 2;
+    if (energyPerDaughter <= 0) {
+        return;
+    }
+
+    microorganism.setEnergy(energyPerDaughter);
+
+    std::unique_ptr<Microorganism> offspring = std::make_unique<Microorganism>(nextEntityId++, "microorganism");
+    offspring->setEnergy(energyPerDaughter);
+    offspring->setMetabolicRate(microorganism.getMetabolicRate());
+
+    Location* destination = adjacentLocations[rand() % adjacentLocations.size()];
+    addEntityToLocation(*offspring, *destination);
+    microorganisms.push_back(std::move(offspring));
+}
+
+void Microbiome::processDeath(Microorganism& microorganism) {
+    // decomposition: a dead microorganism's structural biomass becomes
+    // biomatter that other, living microorganisms can forage for energy,
+    // instead of leaving an inert corpse on the grid indefinitely.
+    Location& location = getGrid()->getLocation(microorganism.getLocationId());
+    removeEntity(microorganism);
+    totalDeaths++;
+
+    std::unique_ptr<Biomatter> newBiomatter = std::make_unique<Biomatter>(nextEntityId++, "biomatter", biomatterYieldPerDeath);
+    addEntityToLocation(*newBiomatter, location);
+    biomatter.push_back(std::move(newBiomatter));
+}
+
+void Microbiome::purgeDepletedBiomatter() {
+    for (std::unique_ptr<Biomatter>& b : biomatter) {
+        if (b->isDepleted() && isEntityPresent(*b)) {
+            removeEntity(*b);
+        }
+    }
+
+    biomatter.erase(
+        std::remove_if(biomatter.begin(), biomatter.end(),
+            [](const std::unique_ptr<Biomatter>& b) {
+                return b->isDepleted();
+            }),
+        biomatter.end()
+    );
 }
 
 void Microbiome::printConsoleRepresentation() {
@@ -94,25 +216,23 @@ void Microbiome::printConsoleRepresentation() {
     for (Location& location : getGrid()->getLocations()) {
         index++;
         std::string toPrint = " ";
-        if (location.getNumEntities() > 0) {
-            int entityId = location.getEntities()[location.getEntities().size() - 1]->getId();
-            Microorganism& microorganism = (Microorganism&) getEntity(entityId);
-            if (microorganism.isDead()) {
-                toPrint = deadMicroorganismRepresentation;
-            }
-            else {
-                toPrint = aliveMicroorganismRepresentation;
 
-                // print + if microorganism has eaten
-                if (microorganism.getTimesEaten() > 0) {
-                    toPrint = subsistingMicroorganismRepresentation;
-                }
+        Microorganism* organism = getMicroorganismAtLocation(location);
+        if (organism != nullptr) {
+            toPrint = aliveMicroorganismRepresentation;
 
-                // print ! if microorganism is low on energy
-                if (microorganism.getEnergy() < 10) {
-                    toPrint = dyingMicroorganismRepresentation;
-                }
+            // print + if microorganism has foraged
+            if (organism->getTimesEaten() > 0) {
+                toPrint = subsistingMicroorganismRepresentation;
             }
+
+            // print ! if microorganism is low on energy
+            if (organism->getEnergy() < 10) {
+                toPrint = dyingMicroorganismRepresentation;
+            }
+        }
+        else if (getBiomatterAtLocation(location) != nullptr) {
+            toPrint = biomatterRepresentation;
         }
 
         std::cout << " " << toPrint << " ";
@@ -130,14 +250,18 @@ void Microbiome::removeEntity(Entity& entity) {
     Environment::removeEntity(entity);
 }
 
-std::vector<Microorganism> Microbiome::getMicroorganisms() {
-    return microorganisms;
+std::vector<Microorganism*> Microbiome::getMicroorganisms() {
+    std::vector<Microorganism*> result;
+    for (std::unique_ptr<Microorganism>& microorganism : microorganisms) {
+        result.push_back(microorganism.get());
+    }
+    return result;
 }
 
 int Microbiome::getNumAliveMicroorganisms() {
     int numAlive = 0;
-    for (Microorganism& microorganism : microorganisms) {
-        if (!microorganism.isDead()) {
+    for (std::unique_ptr<Microorganism>& microorganism : microorganisms) {
+        if (!microorganism->isDead()) {
             numAlive++;
         }
     }
@@ -145,19 +269,16 @@ int Microbiome::getNumAliveMicroorganisms() {
 }
 
 int Microbiome::getNumDeadMicroorganisms() {
-    int numDead = 0;
-    for (Microorganism& microorganism : microorganisms) {
-        if (microorganism.isDead()) {
-            numDead++;
-        }
-    }
-    return numDead;
+    return static_cast<int>(totalDeaths);
 }
 
 int Microbiome::getTotalEnergy() {
     int totalEnergy = 0;
-    for (Microorganism& microorganism : microorganisms) {
-        totalEnergy += microorganism.getEnergy();
+    for (std::unique_ptr<Microorganism>& microorganism : microorganisms) {
+        totalEnergy += microorganism->getEnergy();
+    }
+    for (std::unique_ptr<Biomatter>& b : biomatter) {
+        totalEnergy += b->getEnergy();
     }
     if (totalEnergy < 0) {
         totalEnergy = 0;
@@ -166,8 +287,8 @@ int Microbiome::getTotalEnergy() {
 }
 
 bool Microbiome::isMicroorganismPresent(int id) {
-    for (Microorganism& microorganism : microorganisms) {
-        if (microorganism.getId() == id) {
+    for (std::unique_ptr<Microorganism>& microorganism : microorganisms) {
+        if (microorganism->getId() == id) {
             return true;
         }
     }
@@ -176,17 +297,26 @@ bool Microbiome::isMicroorganismPresent(int id) {
 
 void Microbiome::addMicroorganism(Microorganism microorganism) {
     logger->log("Adding microorganism " + std::to_string(microorganism.getId()) + "...");
-    microorganisms.push_back(microorganism);
+    microorganisms.push_back(std::make_unique<Microorganism>(microorganism));
 }
 
 void Microbiome::removeMicroorganism(int id) {
     logger->log("Removing microorganism " + std::to_string(id) + "...");
-    // recreate vector without the microorganism
-    std::vector<Microorganism> newMicroorganisms;
-    for (Microorganism& microorganism : microorganisms) {
-        if (microorganism.getId() != id) {
-            newMicroorganisms.push_back(microorganism);
-        }
-    }
-    microorganisms = newMicroorganisms;
+    microorganisms.erase(
+        std::remove_if(microorganisms.begin(), microorganisms.end(),
+            [id](const std::unique_ptr<Microorganism>& microorganism) {
+                return microorganism->getId() == id;
+            }),
+        microorganisms.end()
+    );
+}
+
+void Microbiome::purgeMicroorganismsNotInEnvironment() {
+    microorganisms.erase(
+        std::remove_if(microorganisms.begin(), microorganisms.end(),
+            [this](const std::unique_ptr<Microorganism>& microorganism) {
+                return !isEntityPresent(*microorganism);
+            }),
+        microorganisms.end()
+    );
 }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -136,14 +136,62 @@ void testRemovingMicroorganismFromMicrobiome() {
     assert(!microbiome.isMicroorganismPresent(microorganism.getId()));
 
     // verify that microorganism is no longer in the microorganisms vector
-    std::vector<Microorganism> microorganisms = microbiome.getMicroorganisms();
+    std::vector<Microorganism*> microorganisms = microbiome.getMicroorganisms();
     bool microorganismFound = false;
-    for (Microorganism m : microorganisms) {
-        if (m.getId() == microorganism.getId()) {
+    for (Microorganism* m : microorganisms) {
+        if (m->getId() == microorganism.getId()) {
             microorganismFound = true;
         }
     }
     assert(!microorganismFound);
+    std::cout << " --- " << "Success" << std::endl;
+}
+
+void testMicroorganismReproduction() {
+    std::cout << "Test - Microorganism Reproduction";
+    int id = 0;
+    int size = 3;
+    int entityFactor = 1;
+    std::string name = "Test Microbiome";
+    Microbiome microbiome(id, name, size, entityFactor);
+
+    size_t populationBefore = microbiome.getMicroorganisms().size();
+
+    // give one microorganism enough energy to reproduce this tick; the
+    // maximum single-tick metabolic cost (4) can't bring it back under the
+    // reproduction threshold (900), so reproduction is guaranteed to occur.
+    microbiome.getMicroorganisms()[0]->setEnergy(950);
+
+    microbiome.initiateMicroorganismMovement();
+
+    size_t populationAfter = microbiome.getMicroorganisms().size();
+    assert(populationAfter > populationBefore);
+    std::cout << " --- " << "Success" << std::endl;
+}
+
+void testDeathProducesForageableBiomatter() {
+    std::cout << "Test - Death Produces Foragable Biomatter";
+    int id = 0;
+    int size = 3;
+    int entityFactor = 1;
+    std::string name = "Test Microbiome";
+    Microbiome microbiome(id, name, size, entityFactor);
+
+    std::vector<Microorganism*> microorganisms = microbiome.getMicroorganisms();
+    size_t populationSize = microorganisms.size();
+    for (Microorganism* microorganism : microorganisms) {
+        // low enough that any metabolic rate (1-4) kills it this tick
+        microorganism->setEnergy(1);
+    }
+
+    microbiome.initiateMicroorganismMovement();
+
+    assert(microbiome.getNumAliveMicroorganisms() == 0);
+    assert(microbiome.getNumDeadMicroorganisms() == (int) populationSize);
+    // the population's energy didn't just vanish - it should still be
+    // recoverable as biomatter in the environment.
+    assert(microbiome.getTotalEnergy() > 0);
+    std::cout << " --- " << "Success" << std::endl;
 }
 
 
@@ -212,6 +260,8 @@ int main() {
 
     // run microbiome tests
     testMicrobiomeCreation();
+    testMicroorganismReproduction();
+    testDeathProducesForageableBiomatter();
     testSimulationCreation();
 
     // run simulation tests


### PR DESCRIPTION
Recreated from #24, which GitHub auto-closed when its base branch (`add-research-md`) was deleted after merging #23. Same content, now targeting `master` directly since #23 is already merged.

## Summary
Implements the first three items of RESEARCH.md's "suggested near-term ordering" (section 7) — the ones flagged as prerequisites for everything else in the doc:

- **Reproduction** ([#13](https://github.com/Preponderous-Software/microbiome/issues/13)): once a microorganism's energy crosses a threshold, it divides via binary fission into two daughter cells, each getting half its remaining energy minus a fission cost (energetic cost of dividing) and inheriting the parent's metabolic rate.
- **Biomatter on death** ([#14](https://github.com/Preponderous-Software/microbiome/issues/14)): a dead microorganism's biomass now becomes a new `Biomatter` entity in the environment (`src/biomatter.cpp`) instead of an inert corpse. Living microorganisms forage it for energy, depleting it over time, replacing the old fixed-bonus "eat the corpse next to you" mechanic. `getTotalEnergy()` now also counts biomatter, so spent metabolic energy is the only energy that actually leaves the system (closer to real decomposition/nutrient cycling).
- **Chemotaxis**: movement is now probabilistically biased toward adjacent locations containing biomatter (`Microbiome::moveMicroorganism`), instead of a pure uniform-random walk, loosely modeling how real bacteria bias movement up a nutrient gradient.

### A correctness fix this required
`Microbiome` stored microorganisms as `std::vector<Microorganism>`, and the environment's grid holds raw `Entity*` pointers into those objects. Since reproduction needs to grow that container at runtime (and `removeMicroorganism` already rebuilt it from scratch), any reallocation would silently dangle every entity pointer already registered in the grid. Switched to `std::vector<std::unique_ptr<Microorganism>>` (and the same for the new `Biomatter` container), so pointee addresses stay stable regardless of how the outer vector reallocates. `getMicroorganisms()` now returns `std::vector<Microorganism*>` instead of copies, and `removeMicroorganism` is a plain `erase`/`remove_if` rather than a manual rebuild.

### Tuning
Reproduction threshold, fission cost, and biomatter yield/foraging rate were chosen conservatively (see constants at the bottom of `microbiome.h`) since there's no primary producer in this model yet — total system energy is still monotonically non-increasing, so populations still go extinct eventually rather than growing forever, they just also reproduce along the way now. Verified locally: with the default `AppConfig` (10x10 grid, entityFactor 10, no tick cap), population peaks at roughly +20% over the initial count before declining to extinction in ~1000–1100 ticks, and the full 10-simulation default run completes in ~15s.

Left for follow-up PRs, consistent with RESEARCH.md's own framing (each proposal needs its own design/PR): species differentiation, mutation/evolution, quorum sensing/biofilms, horizontal gene transfer, dormancy, environmental gradients, predation beyond foraging.

## Test plan
- `make tests && ./tests` — all existing tests pass, plus two new ones (`testMicroorganismReproduction`, `testDeathProducesForageableBiomatter`) that deterministically exercise the new mechanics.
- `make mbapp && ./mb_app` — ran the full default 10-simulation console app locally; visually confirmed biomatter (`.`) appears on death and persists briefly after foraging, population grows before declining, and simulations still terminate.
- No new compiler warnings (`-pedantic -Wall`).

Drafted by Claude on behalf of Daniel Stephenson.