### PR TITLE
Add curl to the Docker image for healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,18 @@ USER root
 WORKDIR /microbiome
 
 # add build tools
-RUN apt-get update && apt-get install -y make g++ pkg-config libulfius-dev
+RUN apt-get update && apt-get install -y make g++ pkg-config libulfius-dev curl
 
 # add source code
 COPY . .
 
 # build
 RUN make
+
+# the console app (mb_app, the default CMD) doesn't listen on a port; only
+# the webapp (mb_webapp, see docker-compose.yml's microbiome-webapp service)
+# does, on MICROBIOME_WEB_PORT (default 8080).
+EXPOSE 8080
 
 # run
 CMD ["./mb_app"]


### PR DESCRIPTION
Small follow-up to #25/#26: deploying the webapp behind a Docker/Traefik healthcheck needs an HTTP client inside the container, and `ubuntu:18.04` ships neither `curl` nor `wget` by default. Also added `EXPOSE 8080` for documentation (the webapp's default port).

Drafted by Claude on behalf of Daniel Stephenson.