### PR TITLE
Fix Docker build on ubuntu:18.04: pin real Ulfius transitive deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ USER root
 WORKDIR /microbiome
 
 # add build tools
-RUN apt-get update && apt-get install -y make g++ pkg-config libulfius-dev curl
+RUN apt-get update && apt-get install -y make g++ pkg-config curl \
+    libulfius-dev libmicrohttpd-dev libjansson-dev
 
 # add source code
 COPY . .


### PR DESCRIPTION
The gateway's actual production deploy (ubuntu:18.04) failed the Docker build:

\`\`\`
/usr/include/ulfius.h:32:10: fatal error: microhttpd.h: No such file or directory
\`\`\`

Checked bionic's package metadata directly: \`libulfius-dev\` 2.2.4-1 there only \`Depends: libulfius2.2, liborcania-dev, libyder-dev\` — no \`libmicrohttpd-dev\`/\`libjansson-dev\`. Both got pulled in transitively by the newer 2.5.2-4 on focal (what I'd verified against locally in #25/#27), so this only surfaced against the real image. Depend on them explicitly instead of trusting `libulfius-dev`'s (incomplete, on this distro) declared deps.

## Test plan
- `make && ./tests` — still builds clean and all tests pass on Ubuntu 20.04/libulfius 2.5.2 (can't test the actual bionic/2.2.4 path without Docker in this environment, but the fix directly addresses the exact error from the real bionic build log).

Drafted by Claude on behalf of Daniel Stephenson.