### PR TITLE
Fix Docker build: EOL ubuntu:18.04 → 24.04, add docker-build CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+# Verifies the production Docker image builds (this is what the gateway
+# deploy does). No third-party actions: manual checkout, plain run steps.
+name: docker-build
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        run: |
+          git init .
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --depth 1 origin "$GITHUB_SHA"
+          git checkout FETCH_HEAD
+          git submodule update --init --recursive
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        run: docker build -t microbiome-ci .
+      - name: Smoke-test webapp binary exists
+        run: docker run --rm --entrypoint ls microbiome-ci -l mb_webapp mb_app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 USER root
 
 WORKDIR /microbiome


### PR DESCRIPTION
Builds on #28: bionic is EOL and its `libulfius-dev` 2.2.4 also ships no `libulfius.pc`, so the Makefile's `pkg-config --cflags --libs libulfius jansson` expands empty even with the headers fixed — the link step would still miss `-lulfius`. noble's ulfius 2.7.x ships proper pkg-config metadata; the explicit `libmicrohttpd-dev`/`libjansson-dev` deps from #28 are kept.

Adds a `docker-build` CI workflow (no third-party actions: manual checkout + plain `docker build`, smoke-checks both binaries exist in the image) so image breakage is caught in PRs instead of during gateway deploys — **already green on this branch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_